### PR TITLE
Fix type annotation for script tag

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,7 @@ export interface MetaInfo {
 
   link?: { rel: string, href: string, [key: string]: any }[]
   style?: { cssText: string, type: string, [key: string]: any }[]
-  script?: { innerHTML: string, type: string, [key: string]: any }[]
+  script?: { innerHTML?: string, src?: string, type: string, [key: string]: any }[]
   noscript?: { innerHTML: string, [key: string]: any }[]
 
   __dangerouslyDisableSanitizers?: string[]


### PR DESCRIPTION
`innerHTML` should be optional