### PR TITLE
fix: $meta is not defined in Vue interface type (#242)

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -13,6 +13,6 @@ declare module "vue/types/options" {
 
 declare module "vue/types/vue" {
   interface Vue {
-    metaInfo(): MetaInfo
+    $meta(): MetaInfo
   }
 }


### PR DESCRIPTION
Updated Vue method to $meta

Resolves #242