### PR TITLE
fix: follow html specs with regards to end tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 language: node_js
+node_js:
+  - "8"
+  - "11"
 cache:
+  yarn: true
   directories:
-    - $HOME/.npm
-    - $HOME/.yarn-cache
     - node_modules
 branches:
   only:
     - master
-node_js:
-  - "6"
-before_install:
-  - npm i -g yarn --cache-min 999999999
 install:
-  - yarn --force
+  - yarn install
 script:
+  - yarn lint
   - yarn test
-after_script:
-  - yarn run codecov
+after_success:
+  - yarn codecov

--- a/src/server/generators/tagGenerator.js
+++ b/src/server/generators/tagGenerator.js
@@ -37,17 +37,20 @@ export default function _tagGenerator (options = {}) {
           // grab child content from one of these attributes, if possible
           const content = tag.innerHTML || tag.cssText || ''
 
-          // these tag types will have content inserted
-          const closed = ['noscript', 'script', 'style'].indexOf(type) === -1
-
           // generate tag exactly without any other redundant attribute
           const observeTag = tag.once
             ? ''
             : `${attribute}="true" `
 
+          // these tags have no end tag
+          const hasEndTag = !['base', 'meta', 'link'].includes(type)
+
+          // these tag types will have content inserted
+          const hasContent = hasEndTag && ['noscript', 'script', 'style'].includes(type)
+
           // the final string for this specific tag
-          return closed
-            ? `${tagsStr}<${type} ${observeTag}${attrs}/>`
+          return !hasContent
+            ? `${tagsStr}<${type} ${observeTag}${attrs}${hasEndTag ? '/' : ''}>`
             : `${tagsStr}<${type} ${observeTag}${attrs}>${content}</${type}>`
         }, '')
       }


### PR DESCRIPTION
While I was looking at the changes done by the html-minifier when generating my (Nuxt) project, I noticed that vue-meta doesnt strictly follow the html specifications. Both `base`, `link` as `meta` tags dont need to have an endtag. See: https://www.w3.org/TR/html52/document-metadata.html

Fixes: #270 