### PR TITLE
fix: use correct syntax for boolean attributes

### DIFF
--- a/src/server/generators/attrsGenerator.js
+++ b/src/server/generators/attrsGenerator.js
@@ -1,6 +1,51 @@
 export default function _attrsGenerator (options = {}) {
   const { attribute } = options
 
+  // from: https://github.com/kangax/html-minifier/blob/gh-pages/src/htmlminifier.js#L202
+  const booleanAttributes = [
+    'allowfullscreen',
+    'async',
+    'autofocus',
+    'autoplay',
+    'checked',
+    'compact',
+    'controls',
+    'declare',
+    'default',
+    'defaultchecked',
+    'defaultmuted',
+    'defaultselected',
+    'defer',
+    'disabled',
+    'enabled',
+    'formnovalidate',
+    'hidden',
+    'indeterminate',
+    'inert',
+    'ismap',
+    'itemscope',
+    'loop',
+    'multiple',
+    'muted',
+    'nohref',
+    'noresize',
+    'noshade',
+    'novalidate',
+    'nowrap',
+    'open',
+    'pauseonexit',
+    'readonly',
+    'required',
+    'reversed',
+    'scoped',
+    'seamless',
+    'selected',
+    'sortable',
+    'truespeed',
+    'typemustmatch',
+    'visible'
+  ]
+
   /**
    * Generates tag attributes for use on the server.
    *
@@ -17,7 +62,7 @@ export default function _attrsGenerator (options = {}) {
           if (data.hasOwnProperty(attr)) {
             watchedAttrs.push(attr)
             attributeStr += `${
-              typeof data[attr] !== 'undefined'
+              typeof data[attr] !== 'undefined' && !booleanAttributes.includes(attr)
                 ? `${attr}="${data[attr]}"`
                 : attr
             } `


### PR DESCRIPTION
Another issue I noticed by running html-minifier (I am adding an `itemscope`).

Interestingly, it seems the typeof undefined check will never be true ~~(at least with ssr)~~. I wasnt able to give my attribute an undefined value to only print the attribute tag (edit: not sure where but in my Nuxt project somewhere between `nuxt:getNuxtConfig` and `vue-meta:getMetaInfo` the attributes with undefined values are completely stripped).

There are quite a bit of attributes which should never be used on a html/body, but for the sake of completeness I still included them. Maybe in a next major version we could just do a type check on `data[attr] === true`, but that again could result in invalid html when passing custom attributes so not sure what would be best