### PR TITLE
refactor: dont use includes

### DIFF
--- a/src/server/generators/tagGenerator.js
+++ b/src/server/generators/tagGenerator.js
@@ -43,10 +43,10 @@ export default function _tagGenerator (options = {}) {
             : `${attribute}="true" `
 
           // these tags have no end tag
-          const hasEndTag = !['base', 'meta', 'link'].includes(type)
+          const hasEndTag = ['base', 'meta', 'link'].indexOf(type) === -1
 
           // these tag types will have content inserted
-          const hasContent = hasEndTag && ['noscript', 'script', 'style'].includes(type)
+          const hasContent = hasEndTag && ['noscript', 'script', 'style'].indexOf(type) > -1
 
           // the final string for this specific tag
           return !hasContent


### PR DESCRIPTION
its not supported in IE and not polyfilled in vue-meta v1

Before releasing v1.6 we need to fix a previous pr by me as v1 doesnt get polyfilled and we still want to support IE.