### PR TITLE
Typing fix for http-equiv

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,7 +32,7 @@ export interface MetaInfo {
     vmid?: string,
     charset?: string,
     content?: string,
-    'http-equiv'?: 'content-security-policy' | 'refresh',
+    'http-equiv'?: string,
     name?: string,
       [key: string]: any
   }[]


### PR DESCRIPTION
Currently there are only two input values supported for `http-equiv`. In reality there are a couple i'm aware of:

```
content-language
content-type
default-style
refresh
set-cookie
x-ua-compatible
content-security-policy
```