### PR TITLE
[docs] Add notice to avoid confuse

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -1,7 +1,7 @@
 # Server Side Rendering
 
 ```
-Latest version of Nuxt.js has already included Vuex-Meta by default.
+Latest version of Nuxt.js has already included Vue-Meta by default.
 ```
 [Official Document](https://nuxtjs.org/api/pages-head/)
 

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -1,7 +1,7 @@
 # Server Side Rendering
 
 ```
-Latest version of Nuxt.js has already included Vue-Meta by default.
+Information: Nuxt.js includes vue-meta by default.
 ```
 [Official Document](https://nuxtjs.org/api/pages-head/)
 

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -1,5 +1,12 @@
 # Server Side Rendering
 
+```
+Latest version of Nuxt.js has already included Vuex-Meta by default.
+```
+[Official Document](https://nuxtjs.org/api/pages-head/)
+
+<hr>
+
 If you have an isomorphic/universal web application, you'll likely want to render your metadata on the server side as well. Here's how.
 
 ## Add `vue-meta` to the context


### PR DESCRIPTION
Latest version of `Nuxt.js` has already included `Vue-Meta` by default.

We don't need to install again, but seems latest version of docs are not mark this message; It makes me really confuse, so I think if we can put this notice in the docs, that can make other developers more friendly.

Thanks.