### PR TITLE
feat(ts): add microdata meta tag type

### DIFF
--- a/types/vue-meta.d.ts
+++ b/types/vue-meta.d.ts
@@ -62,7 +62,7 @@ export interface MetaPropertyName extends MetaDataProperty {
   template?: (chunk: string) => string
 }
 
-export interface MetaPropertySchemaOrg extends MetaDataProperty {
+export interface MetaPropertyMicrodata extends MetaDataProperty {
   itemprop: string,
   content: string,
   template?: (chunk: string) => string
@@ -129,7 +129,7 @@ export interface MetaInfo {
     href: string
   }
 
-  meta?: (MetaPropertyCharset | MetaPropertyEquiv | MetaPropertyName | MetaPropertySchemaOrg | MetaPropertyProperty)[]
+  meta?: (MetaPropertyCharset | MetaPropertyEquiv | MetaPropertyName | MetaPropertyMicrodata | MetaPropertyProperty)[]
   link?: LinkProperty[]
   style?: StyleProperty[]
   script?: (ScriptPropertyText | ScriptPropertySrc)[]

--- a/types/vue-meta.d.ts
+++ b/types/vue-meta.d.ts
@@ -62,6 +62,12 @@ export interface MetaPropertyName extends MetaDataProperty {
   template?: (chunk: string) => string
 }
 
+export interface MetaPropertySchemaOrg extends MetaDataProperty {
+  itemprop: string,
+  content: string,
+  template?: (chunk: string) => string
+}
+
 // non-w3c interface
 export interface MetaPropertyProperty extends MetaDataProperty {
   property: string,
@@ -123,7 +129,7 @@ export interface MetaInfo {
     href: string
   }
 
-  meta?: (MetaPropertyCharset | MetaPropertyEquiv | MetaPropertyName | MetaPropertyProperty)[]
+  meta?: (MetaPropertyCharset | MetaPropertyEquiv | MetaPropertyName | MetaPropertySchemaOrg | MetaPropertyProperty)[]
   link?: LinkProperty[]
   style?: StyleProperty[]
   script?: (ScriptPropertyText | ScriptPropertySrc)[]


### PR DESCRIPTION
This PR adds support for schema.org meta tags, like the following ones:

```html
<html>

...

<meta itemprop="@type" content="Event">
<meta itemprop="datePublished" content="2019-06-07">

...

</html>
```