### PR TITLE
feat: add ssr benchmark for v3

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -1,0 +1,52 @@
+import v2 from './v2'
+import { v3, v3cached, v3binding } from './v3'
+
+const metaInfo = {
+  title: 'the title',
+  meta: [
+    { charset: 'utf-8' },
+    { name: 'description', content: 'the description' },
+    { name: 'og:description', content: 'the description' },
+    { name: 'twitter:description', content: 'the description' },
+  ],
+  script: [
+    { src: '/script.hs' }
+  ],
+  noscript: [
+    { innerHTML: 'no script' }
+  ]
+}
+
+const count = 10000
+
+const suites = {
+  v2,
+  v3,
+  v3cached,
+  v3binding
+}
+
+async function run() {
+  for (const suite of Object.keys(suites)) {
+    const data = []
+    for (let i = 0; i < count; i++) {
+      data.push(JSON.parse(JSON.stringify({
+        ...metaInfo,
+        title: metaInfo.title + i
+      })))
+    }
+
+    let s = new Date().getTime()
+
+    for (let i = 0; i < count; i++) {
+      const html = await suites[suite](data[i])
+      // console.log(html)
+    }
+
+    const t = new Date().getTime() - s
+
+    console.log(`${suite}:`, t, 'ms')
+  }
+}
+
+run()

--- a/benchmark/v2.js
+++ b/benchmark/v2.js
@@ -1,0 +1,19 @@
+import { defaultOptions as options } from '../src/shared/constants'
+import generateServerInjector from '../src/server/generateServerInjector'
+
+export default function v2(metaInfo) {
+  // generate server injectors
+  for (const key in metaInfo) {
+    if (metaInfo.hasOwnProperty(key)) {
+      metaInfo[key] = generateServerInjector('ssr', options, key, metaInfo[key])
+    }
+  }
+
+  let text = ''
+  for (const key in metaInfo) {
+    text += metaInfo[key].text()
+  }
+
+  return `<head>${text}</head>`
+}
+

--- a/benchmark/v3.js
+++ b/benchmark/v3.js
@@ -1,0 +1,66 @@
+import Vue from 'vue'
+import { promisify } from 'util'
+import LRU from 'lru-cache'
+import { createRenderer, createBundleRenderer } from 'vue-server-renderer'
+
+const renderToString = promisify(createRenderer().renderToString)
+const cachedToString = promisify(createRenderer({
+  cache: new LRU()
+}).renderToString)
+
+function renderChilds(h, metaInfo) {
+  const children = []
+
+  Object.keys(metaInfo).forEach(k => {
+    if (Array.isArray(metaInfo[k])) {
+      metaInfo[k].forEach(attrs => {
+        const html = attrs.innerHTML
+        delete attrs.innerHTML
+        children.push(h(k, { attrs }, html))
+      })
+      return
+    }
+
+    if (k === 'title') {
+      children.push(h('title', null, metaInfo[k]))
+    }
+  })
+
+  return children
+}
+
+
+export async function v3(metaInfo) {
+  const head = new Vue({
+    render(h) {
+      return h('head', null, renderChilds(h, metaInfo))
+    }
+  })
+
+  return await renderToString(head)
+}
+
+export async function v3cached(metaInfo) {
+  const head = new Vue({
+    render(h) {
+      return h('head', null, renderChilds(h, metaInfo))
+    }
+  })
+
+  return await cachedToString(head)
+}
+
+const head = new Vue({
+  data: {
+    metaInfo: {}
+  },
+  render(h) {
+    const metaInfo = this.metaInfo
+    return h('head', null, renderChilds(h, metaInfo))
+  }
+})
+
+export async function v3binding(metaInfo) {
+  head.metaInfo = metaInfo
+  return await cachedToString(head)
+}


### PR DESCRIPTION
As @Atinux raised some (valid) concerns on discord about the performance effect of using `renderToString` for ssr twice as I did in oneof my [proposals](https://github.com/pimlie/vue-meta/tree/feat-proposal/examples/prop-2.0) , see below some numbers. Also @pi0 @manniL 

Not sure if using `createBundleRenderer` could have an effect (but dont think so)

```
$ node -r esm benchmark/run.js
v2: 72 ms
v3: 641 ms
v3cached: 586 ms
v3binding: 135 ms
```