### PR TITLE
fix: ensure hasAttribute exists on $root.$el

### DIFF
--- a/src/shared/mixin.js
+++ b/src/shared/mixin.js
@@ -79,7 +79,7 @@ export default function createMixin(Vue, options) {
             ensuredPush(this.$options, 'beforeMount', () => {
               // if this Vue-app was server rendered, set the appId to 'ssr'
               // only one SSR app per page is supported
-              if (this.$root.$el && this.$root.$el.hasAttribute('data-server-rendered')) {
+              if (this.$root.$el && this.$root.$el.hasAttribute && this.$root.$el.hasAttribute('data-server-rendered')) {
                 this.$root._vueMeta.appId = 'ssr'
               }
             })


### PR DESCRIPTION
If `...$el` is a comment node (which appears to happen during initialization under some circumstances), it will be truthy but won't have `hasAttribute`.