### PR TITLE
fix: set default param to string for escapeSequences

### DIFF
--- a/src/shared/getMetaInfo.js
+++ b/src/shared/getMetaInfo.js
@@ -34,7 +34,7 @@ export default function getMetaInfo(options = {}, component, escapeSequences = [
   }
 
   const escapeOptions = {
-    doEscape: value => escapeSequences.reduce((val, [v, r]) => val.replace(v, r), value)
+    doEscape: value => escapeSequences.reduce((val = '', [v, r]) => val.replace(v, r), value)
   }
 
   disableOptionKeys.forEach((disableKey, index) => {


### PR DESCRIPTION
In some rare cases if `val` is undefined the function will fail because val.replace is not a function.
By setting the default to empty string this can't happen anymore as `replace? will than just operate on a empty string.