### PR TITLE
fix: meta content templates

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -32,11 +32,12 @@ app.use(express.static(__dirname))
 
 app.use(async (req, res, next) => {
   if (!req.url.startsWith('/ssr')) {
-    next()
+    return next()
   }
 
   try {
-    const html = await renderPage()
+    const context = { url: req.url }
+    const html = await renderPage(context)
     res.send(html)
   } catch (e) {
     consola.error('SSR Oops:', e)

--- a/examples/ssr/App.js
+++ b/examples/ssr/App.js
@@ -1,32 +1,82 @@
 import Vue from 'vue'
+import Router from 'vue-router'
 import VueMeta from '../../'
 
+Vue.use(Router)
 Vue.use(VueMeta, {
   tagIDKeyName: 'hid'
 })
 
 export default function createApp () {
-  return new Vue({
-    components: {
-      Hello: {
-        template: '<p>Hello World</p>',
-        metaInfo: {
-          title: 'Hello World',
-          meta: [
-            {
-              hid: 'description',
-              name: 'description',
-              content: 'The description'
-            }
-          ]
+  const Home = {
+    template: `<div>
+      <router-link to="/about">About</router-link>
+
+      <p>Hello World</p>
+    </div>`,
+    metaInfo: {
+      title: 'Hello World',
+      meta: [
+        {
+          hid: 'og:title',
+          name: 'og:title',
+          content: 'Hello World'
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'Hello World'
         }
-      }
-    },
+      ]
+    }
+  }
+
+  const About = {
+    template: `<div>
+      <router-link to="/">Home</router-link>
+
+      <p>About</p>
+    </div>`,
+    metaInfo: {
+      title: 'About World',
+      meta: [
+        {
+          hid: 'og:title',
+          name: 'og:title',
+          content: 'About World'
+        },
+        {
+          hid: 'description',
+          name: 'description',
+          content: 'About World'
+        }
+      ]
+    }
+  }
+
+  const router = new Router({
+    mode: 'history',
+    base: '/ssr',
+    routes: [
+      { path: '/', component: Home },
+      { path: '/about', component: About }
+    ]
+  })
+
+  const app = new Vue({
+    router,
     metaInfo () {
       return {
         title: 'Boring Title',
         htmlAttrs: { amp: true },
         meta: [
+          {
+            skip: this.count < 1,
+            hid: 'og:title',
+            name: 'og:title',
+            template: chunk => `${chunk} - My Site`,
+            content: 'Default Title'
+          },
           {
             hid: 'description',
             name: 'description',
@@ -73,8 +123,6 @@ export default function createApp () {
     },
     template: `
     <div id="app">
-      <hello/>
-
       <p>{{ count }} users loaded</p>
 
       <ul>
@@ -85,6 +133,10 @@ export default function createApp () {
         {{ user.id }}: {{ user.name }}
         </li>
       </ul>
+
+      <router-view />
     </div>`
   })
+
+  return { app, router }
 }

--- a/examples/ssr/browser.js
+++ b/examples/ssr/browser.js
@@ -2,4 +2,5 @@ import createApp from './App'
 
 window.users = []
 
-createApp().$mount('#app')
+const { app } = createApp()
+app.$mount('#app')

--- a/src/client/updaters/tag.js
+++ b/src/client/updaters/tag.js
@@ -1,4 +1,4 @@
-import { booleanHtmlAttributes, commonDataAttributes } from '../../shared/constants'
+import { booleanHtmlAttributes, commonDataAttributes, tagProperties } from '../../shared/constants'
 import { includes } from '../../utils/array'
 import { queryElements, getElementsKey } from '../../utils/elements.js'
 
@@ -48,7 +48,7 @@ export default function updateTag (appId, options = {}, type, tags, head, body) 
 
     for (const attr in tag) {
       /* istanbul ignore next */
-      if (!tag.hasOwnProperty(attr)) {
+      if (!tag.hasOwnProperty(attr) || includes(tagProperties, attr)) {
         continue
       }
 

--- a/src/server/generators/tag.js
+++ b/src/server/generators/tag.js
@@ -3,6 +3,7 @@ import {
   tagsWithoutEndTag,
   tagsWithInnerContent,
   tagAttributeAsInnerContent,
+  tagProperties,
   commonDataAttributes
 } from '../../shared/constants'
 
@@ -43,7 +44,7 @@ export default function tagGenerator ({ ssrAppId, attribute, tagIDKeyName } = {}
         // build a string containing all attributes of this tag
         for (const attr in tag) {
           // these attributes are treated as children on the tag
-          if (tagAttributeAsInnerContent.includes(attr) || attr === 'once') {
+          if (tagAttributeAsInnerContent.includes(attr) || tagProperties.includes(attr)) {
             continue
           }
 

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -92,6 +92,8 @@ export const tagsWithInnerContent = ['noscript', 'script', 'style']
 // Attributes which are inserted as childNodes instead of HTMLAttribute
 export const tagAttributeAsInnerContent = ['innerHTML', 'cssText', 'json']
 
+export const tagProperties = ['once', 'template']
+
 // Attributes which should be added with data- prefix
 export const commonDataAttributes = ['body', 'pbody']
 

--- a/src/shared/getComponentOption.js
+++ b/src/shared/getComponentOption.js
@@ -1,8 +1,6 @@
 import { isFunction, isObject } from '../utils/is-type'
-import { findIndex } from '../utils/array'
 import { defaultInfo } from './constants'
 import { merge } from './merge'
-import { applyTemplate } from './template'
 import { inMetaInfoBranch } from './meta-helpers'
 
 export function getComponentMetaInfo (options = {}, component) {
@@ -23,8 +21,8 @@ export function getComponentMetaInfo (options = {}, component) {
  * @param  {Object} [result={}] - result so far
  * @return {Object} result - final aggregated result
  */
-export function getComponentOption (options = {}, component, result = {}) {
-  const { keyName, metaTemplateKeyName, tagIDKeyName } = options
+export function getComponentOption (options = {}, component, result = {}, iter = 0) {
+  const { keyName } = options
   const { $options, $children } = component
 
   if (component._inactive) {
@@ -59,21 +57,6 @@ export function getComponentOption (options = {}, component, result = {}) {
       }
 
       result = getComponentOption(options, childComponent, result)
-    })
-  }
-
-  if (metaTemplateKeyName && result.meta) {
-    // apply templates if needed
-    result.meta.forEach(metaObject => applyTemplate(options, metaObject))
-
-    // remove meta items with duplicate vmid's
-    result.meta = result.meta.filter((metaItem, index, arr) => {
-      return (
-        // keep meta item if it doesnt has a vmid
-        !metaItem.hasOwnProperty(tagIDKeyName) ||
-        // or if it's the first item in the array with this vmid
-        index === findIndex(arr, item => item[tagIDKeyName] === metaItem[tagIDKeyName])
-      )
     })
   }
 

--- a/src/shared/getComponentOption.js
+++ b/src/shared/getComponentOption.js
@@ -21,7 +21,7 @@ export function getComponentMetaInfo (options = {}, component) {
  * @param  {Object} [result={}] - result so far
  * @return {Object} result - final aggregated result
  */
-export function getComponentOption (options = {}, component, result = {}, iter = 0) {
+export function getComponentOption (options = {}, component, result = {}) {
   const { keyName } = options
   const { $options, $children } = component
 

--- a/src/shared/getMetaInfo.js
+++ b/src/shared/getMetaInfo.js
@@ -32,12 +32,13 @@ export default function getMetaInfo (options = {}, info, escapeSequences = [], c
   if (info.meta) {
     // remove meta items with duplicate vmid's
     info.meta = info.meta.filter((metaItem, index, arr) => {
-      return (
-        // keep meta item if it doesnt has a vmid
-        !metaItem.hasOwnProperty(tagIDKeyName) ||
-        // or if it's the first item in the array with this vmid
-        index === findIndex(arr, item => item[tagIDKeyName] === metaItem[tagIDKeyName])
-      )
+      const hasVmid = metaItem.hasOwnProperty(tagIDKeyName)
+      if (!hasVmid) {
+        return true
+      }
+
+      const isFirstItemForVmid = index === findIndex(arr, item => item[tagIDKeyName] === metaItem[tagIDKeyName])
+      return isFirstItemForVmid
     })
 
     // apply templates if needed

--- a/src/shared/getMetaInfo.js
+++ b/src/shared/getMetaInfo.js
@@ -1,3 +1,4 @@
+import { findIndex } from '../utils/array'
 import { escapeMetaInfo } from '../shared/escaping'
 import { applyTemplate } from './template'
 
@@ -9,6 +10,7 @@ import { applyTemplate } from './template'
  * @return {Object} - returned meta info
  */
 export default function getMetaInfo (options = {}, info, escapeSequences = [], component) {
+  const { tagIDKeyName } = options
   // Remove all "template" tags from meta
 
   // backup the title chunk in case user wants access to it
@@ -25,6 +27,21 @@ export default function getMetaInfo (options = {}, info, escapeSequences = [], c
   // as the other tags
   if (info.base) {
     info.base = Object.keys(info.base).length ? [info.base] : []
+  }
+
+  if (info.meta) {
+    // remove meta items with duplicate vmid's
+    info.meta = info.meta.filter((metaItem, index, arr) => {
+      return (
+        // keep meta item if it doesnt has a vmid
+        !metaItem.hasOwnProperty(tagIDKeyName) ||
+        // or if it's the first item in the array with this vmid
+        index === findIndex(arr, item => item[tagIDKeyName] === metaItem[tagIDKeyName])
+      )
+    })
+
+    // apply templates if needed
+    info.meta.forEach(metaObject => applyTemplate(options, metaObject))
   }
 
   return escapeMetaInfo(options, info, escapeSequences)

--- a/src/shared/merge.js
+++ b/src/shared/merge.js
@@ -10,6 +10,10 @@ export function arrayMerge ({ component, tagIDKeyName, metaTemplateKeyName, cont
   // using an O(1) lookup associative array exploit
   const destination = []
 
+  if (!target.length && !source.length) {
+    return destination
+  }
+
   target.forEach((targetItem, targetIndex) => {
     // no tagID so no need to check for duplicity
     if (!targetItem[tagIDKeyName]) {
@@ -53,12 +57,17 @@ export function arrayMerge ({ component, tagIDKeyName, metaTemplateKeyName, cont
     }
 
     const sourceTemplate = sourceItem[metaTemplateKeyName]
-
     if (!sourceTemplate) {
       // use parent template and child content
       applyTemplate({ component, metaTemplateKeyName, contentKeyName }, sourceItem, targetTemplate)
-    } else if (!sourceItem[contentKeyName]) {
-      // use child template and parent content
+
+      // set template to true to indicate template was already applied
+      sourceItem.template = true
+      return
+    }
+
+    if (!sourceItem[contentKeyName]) {
+      // use parent content and child template
       applyTemplate({ component, metaTemplateKeyName, contentKeyName }, sourceItem, undefined, targetItem[contentKeyName])
     }
   })

--- a/src/shared/template.js
+++ b/src/shared/template.js
@@ -1,13 +1,23 @@
 import { isUndefined, isFunction } from '../utils/is-type'
 
 export function applyTemplate ({ component, metaTemplateKeyName, contentKeyName }, headObject, template, chunk) {
-  if (isUndefined(template)) {
+  if (template === true || headObject[metaTemplateKeyName] === true) {
+    // abort, template was already applied
+    return false
+  }
+
+  if (isUndefined(template) && headObject[metaTemplateKeyName]) {
     template = headObject[metaTemplateKeyName]
-    delete headObject[metaTemplateKeyName]
+    headObject[metaTemplateKeyName] = true
   }
 
   // return early if no template defined
   if (!template) {
+    // cleanup faulty template properties
+    if (headObject.hasOwnProperty(metaTemplateKeyName)) {
+      delete headObject[metaTemplateKeyName]
+    }
+
     return false
   }
 

--- a/test/unit/getMetaInfo.test.js
+++ b/test/unit/getMetaInfo.test.js
@@ -251,7 +251,7 @@ describe('getMetaInfo', () => {
       }
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -262,7 +262,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'Test title - My page'
+          content: 'Test title - My page',
+          template: true
         }
       ],
       base: [],
@@ -272,7 +273,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('properly uses function meta templates', () => {
@@ -290,7 +294,7 @@ describe('getMetaInfo', () => {
       }
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -301,7 +305,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'Test title - My page'
+          content: 'Test title - My page',
+          template: true
         }
       ],
       base: [],
@@ -311,7 +316,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('properly uses content only if template is not defined', () => {
@@ -460,7 +468,7 @@ describe('getMetaInfo', () => {
       render: h => h('div', null, [h('merge-child')])
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -471,7 +479,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'An important title! - My page'
+          content: 'An important title! - My page',
+          template: true
         }
       ],
       base: [],
@@ -481,7 +490,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('properly uses meta templates with one-level-deep nested children template', () => {
@@ -514,7 +526,7 @@ describe('getMetaInfo', () => {
       render: h => h('div', null, [h('merge-child')])
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -525,7 +537,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'Test title - My page'
+          content: 'Test title - My page',
+          template: true
         }
       ],
       base: [],
@@ -535,7 +548,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('properly uses meta templates with one-level-deep nested children template and content', () => {
@@ -569,7 +585,7 @@ describe('getMetaInfo', () => {
       render: h => h('div', null, [h('merge-child')])
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -580,7 +596,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'An important title! - My page'
+          content: 'An important title! - My page',
+          template: true
         }
       ],
       base: [],
@@ -590,7 +607,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('properly uses meta templates with one-level-deep nested children when parent has no template', () => {
@@ -623,7 +643,7 @@ describe('getMetaInfo', () => {
       render: h => h('div', null, [h('merge-child')])
     })
 
-    expect(getMetaInfo(component)).toEqual({
+    const expectedMetaInfo = {
       title: 'Hello',
       titleChunk: 'Hello',
       titleTemplate: '%s',
@@ -634,7 +654,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'An important title! - My page'
+          content: 'An important title! - My page',
+          template: true
         }
       ],
       base: [],
@@ -644,7 +665,10 @@ describe('getMetaInfo', () => {
       noscript: [],
       __dangerouslyDisableSanitizers: [],
       __dangerouslyDisableSanitizersByTagID: {}
-    })
+    }
+
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
+    expect(getMetaInfo(component)).toEqual(expectedMetaInfo)
   })
 
   test('no errors when metaInfo returns nothing', () => {
@@ -721,7 +745,8 @@ describe('getMetaInfo', () => {
         {
           vmid: 'og:title',
           property: 'og:title',
-          content: 'Test title - My page'
+          content: 'Test title - My page',
+          template: true
         }
       ],
       base: [],


### PR DESCRIPTION
Both in v1 as in v2 the meta content templates caused wrong content if you would eg run the exact same tests multiple times. This was mainly caused by the fact that templates where removed once used so if both parent and child had templates defined on the second run the other template would be used.

So instead of explicitly removing templates we now keep track if a template has been applied for that specific meta property by setting template to true so a template is never applied twice (this was found in #426).

This fix could potentially break advanced configs like eg chained templates through multiple components though (but not sure if that was even possible, never tried it), but I think its better to support basic functionality as in 426 then advanced configs for now.
