### PR TITLE
fix(types): missing property "content" of MetaPropertyEquiv

### DIFF
--- a/types/vue-meta.d.ts
+++ b/types/vue-meta.d.ts
@@ -59,7 +59,7 @@ export interface MetaPropertyCharset extends MetaDataProperty {
 
 export interface MetaPropertyEquiv extends MetaDataProperty {
   httpEquiv: string,
-  name: string,
+  content: string,
   template?: (chunk: string) => string
 }
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#Notes) and [WHATWG](https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element), a `<meta http-equiv>` should contain a `content` attribute and no `name` attribute. The `MetaPropertyEquiv` interface seems wrong about this case and this PR is going to fix the issue.

Closes #435.