### PR TITLE
fix(types): missing type for `json` property

### DIFF
--- a/types/vue-meta.d.ts
+++ b/types/vue-meta.d.ts
@@ -136,6 +136,16 @@ export interface ScriptPropertySrcCallback extends ScriptPropertyBase {
   callback: CallbackFn
 }
 
+type JsonVal = string | number | boolean | JsonObj | JsonObj[] | null
+
+interface JsonObj {
+  [key: string]: JsonVal | JsonVal[]
+}
+
+export interface ScriptPropertyJson extends ScriptPropertyBase {
+  json: JsonObj
+}
+
 export interface NoScriptProperty extends MetaDataProperty {
   innerHTML: string,
 }
@@ -156,7 +166,7 @@ export interface MetaInfo {
   meta?: (MetaPropertyCharset | MetaPropertyEquiv | MetaPropertyName | MetaPropertyMicrodata | MetaPropertyProperty)[]
   link?: (LinkPropertyBase | LinkPropertyHref | LinkPropertyHrefCallback)[]
   style?: StyleProperty[]
-  script?: (ScriptPropertyText | ScriptPropertySrc | ScriptPropertySrcCallback)[]
+  script?: (ScriptPropertyText | ScriptPropertySrc | ScriptPropertySrcCallback | ScriptPropertyJson)[]
   noscript?: NoScriptProperty[]
 
   __dangerouslyDisableSanitizers?: string[]


### PR DESCRIPTION
The new feature added in #415 does not have a `json` property type definition, so TypeScript compilation fails. This PR adds new interfaces and types.