### PR TITLE
types: export types for meta, link, script interfaces

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,5 +7,21 @@ export {
   VueMetaOptions,
   VueMetaPlugin,
   MetaInfo,
-  MetaInfoSSR
+  MetaInfoSSR,
+  AttributeProperty,
+  LinkPropertyBase,
+  LinkPropertyHref,
+  LinkPropertyHrefCallback,
+  MetaPropertyCharset,
+  MetaPropertyEquiv,
+  MetaPropertyName,
+  MetaPropertyMicrodata,
+  MetaPropertyProperty,
+  NoScriptProperty,
+  ScriptPropertyBase,
+  ScriptPropertyText,
+  ScriptPropertySrc,
+  ScriptPropertySrcCallback,
+  ScriptPropertyJson,
+  StyleProperty
 } from './vue-meta'


### PR DESCRIPTION
To be able to annotate those in user's code when stored individually.

Resolves #440