### PR TITLE
docs: Use direct link to Nuxt documentation

### DIFF
--- a/docs/guide/frameworks.md
+++ b/docs/guide/frameworks.md
@@ -8,7 +8,7 @@ Proceed to the [Gridsome documentation](https://gridsome.org/docs)
 
 ## Nuxt.js
 
-Proceed to the [Nuxt.js documentation](https://nuxtjs.org/api)
+Proceed to the [Nuxt.js documentation](https://nuxtjs.org/api/pages-head)
 
 ## Ream
 


### PR DESCRIPTION
Addresses issue #445 - Links to more specific documentation for Nuxt head method.