### PR TITLE
feat: try to detect global mixins adding meta info

### DIFF
--- a/src/shared/mixin.js
+++ b/src/shared/mixin.js
@@ -1,5 +1,6 @@
 import { triggerUpdate } from '../client/update'
 import { isUndefined, isFunction } from '../utils/is-type'
+import { find } from '../utils/array'
 import { ensuredPush } from '../utils/ensure'
 import { rootConfigKey } from './constants'
 import { hasMetaInfo } from './meta-helpers'
@@ -46,7 +47,7 @@ export default function createMixin (Vue, options) {
           // use nextTick so the children should be added to $root
           this.$nextTick(() => {
             // find the first child that lists fnOptions
-            const child = $root.$children.find(c => c.$vnode && c.$vnode.fnOptions)
+            const child = find($root.$children, c => c.$vnode && c.$vnode.fnOptions)
             if (child && child.$vnode.fnOptions[options.keyName]) {
               warn(`VueMeta has detected a possible global mixin which adds a ${options.keyName} property to all Vue components on the page. This could cause severe performance issues. If possible, use $meta().addApp to add meta information instead`)
             }

--- a/src/shared/mixin.js
+++ b/src/shared/mixin.js
@@ -19,12 +19,13 @@ export default function createMixin (Vue, options) {
       const rootKey = '$root'
       const $root = this[rootKey]
       const $options = this.$options
+      const devtoolsEnabled = Vue.config.devtools
 
       Object.defineProperty(this, '_hasMetaInfo', {
         configurable: true,
         get () {
           // Show deprecation warning once when devtools enabled
-          if (Vue.config.devtools && !$root[rootConfigKey].deprecationWarningShown) {
+          if (devtoolsEnabled && !$root[rootConfigKey].deprecationWarningShown) {
             warn('VueMeta DeprecationWarning: _hasMetaInfo has been deprecated and will be removed in a future version. Please use hasMetaInfo(vm) instead')
             $root[rootConfigKey].deprecationWarningShown = true
           }
@@ -43,7 +44,7 @@ export default function createMixin (Vue, options) {
         $root[rootConfigKey] = { appId }
         appId++
 
-        if ($root.$options[options.keyName]) {
+        if (devtoolsEnabled && $root.$options[options.keyName]) {
           // use nextTick so the children should be added to $root
           this.$nextTick(() => {
             // find the first child that lists fnOptions

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -11,6 +11,19 @@
 // which means the polyfills are removed for other build formats
 const polyfill = process.env.NODE_ENV === 'test'
 
+export function find (array, predicate, thisArg) {
+  if (polyfill && !Array.prototype.find) {
+    // idx needs to be a Number, for..in returns string
+    for (let idx = 0; idx < array.length; idx++) {
+      if (predicate.call(thisArg, array[idx], idx, array)) {
+        return array[idx]
+      }
+    }
+    return
+  }
+  return array.find(predicate, thisArg)
+}
+
 export function findIndex (array, predicate, thisArg) {
   if (polyfill && !Array.prototype.findIndex) {
     // idx needs to be a Number, for..in returns string

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { findIndex, includes, toArray } from '../../src/utils/array'
+import { find, findIndex, includes, toArray } from '../../src/utils/array'
 import { ensureIsArray } from '../../src/utils/ensure'
 import { hasGlobalWindowFn } from '../../src/utils/window'
 
@@ -29,6 +29,17 @@ describe('shared', () => {
   })
 
   /* eslint-disable no-extend-native */
+  test('find polyfill', () => {
+    const _find = Array.prototype.find
+    Array.prototype.find = false
+
+    const arr = [1, 2, 3]
+    expect(find(arr, (v, i) => i === 0)).toBe(1)
+    expect(find(arr, (v, i) => i === 3)).toBe(undefined)
+
+    Array.prototype.find = _find
+  })
+
   test('findIndex polyfill', () => {
     const _findIndex = Array.prototype.findIndex
     Array.prototype.findIndex = false


### PR DESCRIPTION
fix: make sure that beforeMount hook to hydrate from ssr is only added once (disclaimer, havent been able to trigger an issue with this manually tough)

Recently there have been some issues due to third party libs adding a global mixin which sets meta information. Since v2.3 that is not the recommended approach anymore (using addApp is). This pr tries to detect if a global mixin adding _keyName_ was used and logs a warning about that