### PR TITLE
fix: still traverse children when metainfo doesnt return object

### DIFF
--- a/src/shared/getComponentOption.js
+++ b/src/shared/getComponentOption.js
@@ -40,13 +40,12 @@ export function getComponentOption (options, component, result) {
     // because Vue caches those internally
     const data = $metaInfo || $options[keyName]
 
-    // ignore data if its not an object, then we keep our previous result
-    if (!isObject(data)) {
-      return result
+    // only merge data with result when its an object
+    // eg it could be a function when metaInfo() returns undefined
+    // dueo to the or statement above
+    if (isObject(data)) {
+      result = merge(result, data, options)
     }
-
-    // merge with existing options
-    result = merge(result, data, options)
   }
 
   // collect & aggregate child options if deep = true

--- a/src/shared/mixin.js
+++ b/src/shared/mixin.js
@@ -135,6 +135,7 @@ export default function createMixin (Vue, options) {
 
       // do not trigger refresh on the server side
       if (this.$isServer) {
+        /* istanbul ignore next */
         return
       }
 

--- a/test/unit/getComponentOptions.test.js
+++ b/test/unit/getComponentOptions.test.js
@@ -130,4 +130,37 @@ describe('getComponentOption', () => {
     expect(inMetaInfoBranch(wrapper.vm.$children[1].$children[0])).toBe(true)
     expect(inMetaInfoBranch(wrapper.vm.$children[2])).toBe(false)
   })
+
+  test('retrieves child options even if parent returns null', () => {
+    const localVue = loadVueMetaPlugin({ keyName: 'foo' })
+
+    localVue.component('meta-child', {
+      foo: { bar: 'baz' },
+      render (h) {
+        return h('div', this.$slots.default)
+      }
+    })
+
+    localVue.component('nometa-child', {
+      render (h) {
+        return h('div', this.$slots.default)
+      }
+    })
+
+    const component = localVue.component('parent', {
+      foo: () => {},
+      render: h => h('div', null, [
+        h('meta-child')
+      ])
+    })
+
+    const wrapper = mount(component, { localVue })
+
+    const mergedOption = getComponentOption({ keyName: 'foo' }, wrapper.vm)
+
+    expect(mergedOption).toEqual({ bar: 'baz' })
+    expect(wrapper.vm.$children[0]._vueMeta).toBe(true)
+
+    expect(inMetaInfoBranch(wrapper.vm.$children[0])).toBe(true)
+  })
 })


### PR DESCRIPTION
Fixes: #468 