### PR TITLE
docs: add missing comma in API docs

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -433,7 +433,7 @@ When passing an array or object to the `json` property the keys and values of th
 {
   metaInfo: {
     script: [{
-      type: 'application/ld+json'
+      type: 'application/ld+json',
       json: {
         '@context': 'http://schema.org',
         unsafe: '<p>hello</p>'


### PR DESCRIPTION
Adds a missing comma in the code example in the "Add JSON data" API docs.