### PR TITLE
feat: add amp-boilerplate as boolean attribute (resolves: #530)

### DIFF
--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -113,6 +113,7 @@ export const commonDataAttributes = ['body', 'pbody']
 export const booleanHtmlAttributes = [
   'allowfullscreen',
   'amp',
+  'amp-boilerplate',
   'async',
   'autofocus',
   'autoplay',


### PR DESCRIPTION
According to the AMP specification, documents [need to include](https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate/) a style tag with the boolean attribute `amp-boilerplate` in the `<head>` of the page. At the moment, adding `amp-boilerplate: true` to a style object in `htmlAttrs` outputs `<style amp-boilerplate="true">`, which leads to an AMP validation error. For this reason, `amp-boilerplate` should be added to the 
`booleanHtmlAttributes`, as it has already been done for the attribute `amp`.