### PR TITLE
fix: unexpected behavior { body: false }

### DIFF
--- a/src/utils/elements.js
+++ b/src/utils/elements.js
@@ -11,9 +11,9 @@ export function getTag (tags, tag) {
 }
 
 export function getElementsKey ({ body, pbody }) {
-  return body
+  return body === true || body === 'true'
     ? 'body'
-    : (pbody ? 'pbody' : 'head')
+    : (pbody === true || pbody === 'true' ? 'pbody' : 'head')
 }
 
 export function queryElements (parentNode, { appId, attribute, type, tagIDKeyName }, attributes) {


### PR DESCRIPTION
It doesn't matter what value you set for the `body` of `pbody`.  It works the same as you set it to `true`.