### PR TITLE
fix: also set ssrAppId for first Vue app when ssrAttribute exists

### DIFF
--- a/examples/ssr/App.js
+++ b/examples/ssr/App.js
@@ -66,8 +66,7 @@ export default function createApp () {
     ]
   })
 
-  const app = new Vue({
-    router,
+  const App = ({
     metaInfo () {
       return {
         title: 'Boring Title',
@@ -155,6 +154,11 @@ export default function createApp () {
 
       <router-view />
     </div>`
+  })
+
+  const app = new Vue({
+    router,
+    render: h => h(App)
   })
 
   const { set } = app.$meta().addApp('custom')


### PR DESCRIPTION
This should resolve #404 and resolve #562 

@kevinmarrec Would this fix be an issue with Vuetify? I know previously we had issues with that because they start new Vueapp's for modals etc. But I would guess that if you use Vuetify with SSR the Vue app that uses Vuetify will be initiated first?

I feel this fix is a bit hacky, but I dont think there is a proper way that vue-meta can currently pass the appId from ssr to the client without introducing a breaking change. This fix should handle like 99+% of the normal use-cases (if Vuetify plays along).

(The reverts are just because I first pushed on master, but then decided it was better to do a PR first)