### PR TITLE
docs: add meta description example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@
       htmlAttrs: {
         lang: 'en',
         amp: true
-      }
+      },
+      meta: [
+        {
+          name: 'description',
+          content: 'Welcome to my example app!'
+        }
+      ]
     }
   }
 </script>


### PR DESCRIPTION
I wanted to add a `<meta name="description" content="...">` tag to my project that uses `vue-meta`.

-----

This was my process:

1. Search "vue-meta docs" 
![image](https://user-images.githubusercontent.com/852873/90427094-ee7aa800-e076-11ea-94af-d0b143eb5057.png)
2. Click the first result, scroll down to readme
![image](https://user-images.githubusercontent.com/852873/90427146-04886880-e077-11ea-82b9-824a34589eaf.png)
3. Nothing about description, click examples 
![image](https://user-images.githubusercontent.com/852873/90427216-1833cf00-e077-11ea-93cd-80d85d93e8e0.png)
4. Too much stuff, go back and click docs, and then guide, and then `Defining metaInfo`. Nothing, so search "description", still nothing 
![image](https://user-images.githubusercontent.com/852873/90427415-59c47a00-e077-11ea-89ab-b6fb8ab6928c.png)

-----

This PR solves this flow for me by showing the information I was after on the readme:

![image](https://user-images.githubusercontent.com/852873/90427605-9d1ee880-e077-11ea-9280-f85e4a07db67.png)

