### PR TITLE
fix:(MetaConfig.description defaults)

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -14,7 +14,8 @@ export const defaultConfig: MetaConfig = {
     valueAttribute: 'charset'
   },
   description: {
-    tag: 'meta'
+    tag: 'meta',
+    keyAttribute: 'name'
   },
   og: {
     group: true,


### PR DESCRIPTION
The default configuration for `description` property in `MetaConfig` will currently render the following for the description meta tag (missing `name="description"` attribute):

```html
<meta content="Test description content">
```

Without overriding the default config, it should ideally render as:

```html
<meta name="description" content="Test description content">
```

Fix for this is to update `MetaConfig.description` in `config/default.ts`:

```javascript
  description: {
    tag: 'meta',
    keyAttribute: 'name'
  },
```