### PR TITLE
Add `theme-color` meta tag

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -27,6 +27,10 @@ export const defaultConfig: MetaConfig = {
     namespacedAttribute: true,
     tag: 'meta'
   },
+  'theme-color': {
+    tag: 'meta',
+    keyAttribute: 'name',
+  },
   htmlAttrs: {
     attributesFor: 'html'
   },


### PR DESCRIPTION
This tag is a nice enhancement for [PWAs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) and some social media embeds (e.g. Discord link previews)