### PR TITLE
possible fix for <meta name="meta"> (meta-key) [#696]

### DIFF
--- a/src/config/tags.ts
+++ b/src/config/tags.ts
@@ -13,7 +13,7 @@ export const tags: MetaTagsConfig = {
   },
   meta: {
     contentAsAttribute: true,
-    keyAttribute: 'name',
+    nameless: true,
     attributes: ['content', 'name', 'http-equiv', 'charset']
   },
   link: {


### PR DESCRIPTION
fixes #696

Currently when using 
```ts
useMeta({
    meta: [
      { name: 'author', content: 'myself'},
    ],
});
```

it will render:
```
<meta name="meta" content="myself">
```

with this little change this issue should be resolve, idk if this is the proper way though. Just hoping I can help