### PR TITLE
This code is to correct an issue where the 'name' property

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -178,7 +178,7 @@ export function renderTag (
       if (!nameless) {
         const keyAttribute = config.keyAttribute || getTagConfig('keyAttribute')
         if (keyAttribute) {
-          attributes[keyAttribute] = fullName
+          attributes[keyAttribute] = (fullName !== tag ? fullName : attributes[keyAttribute] || undefined) //
         }
       }
 


### PR DESCRIPTION
#### Issue
https://github.com/nuxt/vue-meta/issues/696

#### Fix
This code is to correct an issue where the 'name' property provided in a meta object,  was being set with the tag name rather than property value
