### PR TITLE
Return the use of titleTemplate function|string

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -203,8 +203,8 @@ export function renderTag (
     const title = template
       ? isFunction(template)
         ? template(content)
-        : template.replace( /%s/g, content)
-      : content;
+        : template.replace(/%s/g, content)
+      : content
     document.title = title
     return
   }

--- a/src/render.ts
+++ b/src/render.ts
@@ -199,7 +199,13 @@ export function renderTag (
       : tag
 
   if (finalTag === 'title' && !context.isSSR) {
-    document.title = content
+    const { titleTemplate: template } = context.metainfo
+    const title = template
+      ? isFunction(template)
+        ? template(content)
+        : template.replace( /%s/g, content)
+      : content;
+    document.title = title
     return
   }
 


### PR DESCRIPTION
#### Issue:
https://github.com/nuxt/vue-meta/issues/702

#### Fix
 This code is to return the use of titleTemplate function|string without having to pass a slot
this **DOES not allow** nested templating of the title, if a lower component has a titleTemplate it will override parents