### PR TITLE
Fix: change code  to prevent class attributes from being output with a comma

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -269,7 +269,8 @@ export function renderAttributes (
     let content = getSlotContent(context, `${key}(${attr})`, data[attr], data)
 
     if (isArray(content)) {
-      content = content.join(',')
+      const joinWith: string = (attr === 'class') ? ' ' : ','
+      content = content.join(joinWith)
     }
 
     el.setAttribute(attr, content || '')


### PR DESCRIPTION
#### ISSUE
https://github.com/nuxt/vue-meta/issues/710

#### Description
This code change is to prevent class attributes from being output with a comma separating them.