### PR TITLE
fix- prevent titleTemplate from rendering as a tag

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -201,7 +201,7 @@ export class MetaManager {
       const config = this.config[key] || {}
 
       if (key === 'titleTemplate') {
-        continue;
+        continue
       }
 
       let renderedNodes = renderMeta(

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -200,6 +200,10 @@ export class MetaManager {
     for (const key in active) {
       const config = this.config[key] || {}
 
+      if (key === 'titleTemplate') {
+        continue;
+      }
+
       let renderedNodes = renderMeta(
         { isSSR, metainfo: active, slots },
         key,


### PR DESCRIPTION
#### Github Issue
https://github.com/nuxt/vue-meta/issues/702

#### Description

This code is to correct an issue where the titleTemplate string or function was being rendered as a tag in the head