### PR TITLE
fix: meta content types as string | null | undefined

### DIFF
--- a/types/vue-meta.d.ts
+++ b/types/vue-meta.d.ts
@@ -73,32 +73,32 @@ export interface MetaPropertyCharset extends MetaDataProperty {
 
 export interface MetaPropertyEquiv extends MetaDataProperty {
   httpEquiv: string,
-  content: string,
+  content: string | null | undefined,
   template?: (chunk: string) => string
 }
 
 export interface MetaPropertyTrueEquiv extends MetaDataProperty {
   'http-equiv': string,
-  content: string,
+  content: string | null | undefined,
   template?: (chunk: string) => string
 }
 
 export interface MetaPropertyName extends MetaDataProperty {
   name: string,
-  content: string,
+  content: string | null | undefined,
   template?: (chunk: string) => string
 }
 
 export interface MetaPropertyMicrodata extends MetaDataProperty {
   itemprop: string,
-  content: string,
+  content: string | null | undefined,
   template?: (chunk: string) => string
 }
 
 // non-w3c interface
 export interface MetaPropertyProperty extends MetaDataProperty {
   property: string,
-  content: string,
+  content: string | null | undefined,
   template?: (chunk: string) => string
 }
 
@@ -143,7 +143,7 @@ export interface ScriptPropertyBase extends MetaDataProperty {
 }
 
 export interface ScriptPropertyText extends ScriptPropertyBase {
-  innerHTML: string
+  innerHTML: string | null | undefined
 }
 
 export interface ScriptPropertySrc extends ScriptPropertyBase {
@@ -167,7 +167,7 @@ export interface ScriptPropertyJson extends ScriptPropertyBase {
 }
 
 export interface NoScriptProperty extends MetaDataProperty {
-  innerHTML: string,
+  innerHTML: string | null | undefined,
 }
 
 export interface MetaInfo {


### PR DESCRIPTION
This pull request fix an error in the meta tags content typings to support null or undefined values, as [the docs](https://vue-meta.nuxtjs.org/guide/special.html) say.