### PR TITLE
Error in event handler for "hook:mounted": "TypeError: Cannot create property 'initializing' on boolean 'true'"

### DIFF
--- a/src/shared/mixin.js
+++ b/src/shared/mixin.js
@@ -21,6 +21,8 @@ export default function createMixin (Vue, options) {
       const $root = this[rootKey]
       const $options = this.$options
       const devtoolsEnabled = Vue.config.devtools
+      
+      $root[rootConfigKey] = {}
 
       Object.defineProperty(this, '_hasMetaInfo', {
         configurable: true,


### PR DESCRIPTION
### $root[rootConfigKey] is not an object when mounted with uni-app, because uni-app onLoad life cycle priority is higher

So beforeCreate needs to be initialized once when mounting $root[rootConfigKey] = {}

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/26755049/204519127-4e929a0a-055a-41b8-b2db-d09c1569b45b.png">